### PR TITLE
Upgrade terraform

### DIFF
--- a/instance/data.tf
+++ b/instance/data.tf
@@ -6,9 +6,9 @@ data "openstack_images_image_v2" "ubuntu" {
 }
 
 data "template_file" "userdata" {
-  template = "${file("${path.module}/templates/userdata.yml")}"
+  template = file("${path.module}/templates/userdata.yml")
 
-  vars = {
-    #TODO add vars here
-  }
+  vars = {}
+  #TODO add vars here
 }
+

--- a/instance/instance.tf
+++ b/instance/instance.tf
@@ -1,12 +1,13 @@
 resource "openstack_compute_instance_v2" "my-instance" {
   name            = "${var.instance_name}-${var.petname}"
-  flavor_name     = "${var.flavor}"
-  image_id        = "${data.openstack_images_image_v2.ubuntu.id}"
+  flavor_name     = var.flavor
+  image_id        = data.openstack_images_image_v2.ubuntu.id
   key_pair        = "my-keypair"
-  security_groups = ["${var.sec_id}"]
-  user_data       = "${data.template_file.userdata.rendered}"
+  security_groups = [var.sec_id]
+  user_data       = data.template_file.userdata.rendered
 
   network {
     name = "public-belwue"
   }
 }
+

--- a/instance/instance.tf
+++ b/instance/instance.tf
@@ -3,7 +3,7 @@ resource "openstack_compute_instance_v2" "my-instance" {
   flavor_name     = var.flavor
   image_id        = data.openstack_images_image_v2.ubuntu.id
   key_pair        = "my-keypair"
-  security_groups = [var.sec_id]
+  security_groups = [var.sec_name]
   user_data       = data.template_file.userdata.rendered
 
   network {

--- a/instance/output.tf
+++ b/instance/output.tf
@@ -1,3 +1,4 @@
 output "ip" {
-  value = "${openstack_compute_instance_v2.my-instance.access_ip_v4}"
+  value = openstack_compute_instance_v2.my-instance.access_ip_v4
 }
+

--- a/instance/variables.tf
+++ b/instance/variables.tf
@@ -3,13 +3,14 @@ variable "flavor" {
 }
 
 variable "sec_id" {
-  type = "string"
+  type = string
 }
 
 variable "petname" {
-  type = "string"
+  type = string
 }
 
 variable "instance_name" {
-  type = "string"
+  type = string
 }
+

--- a/instance/variables.tf
+++ b/instance/variables.tf
@@ -2,7 +2,7 @@ variable "flavor" {
   default = "m1.nano"
 }
 
-variable "sec_id" {
+variable "sec_name" {
   type = string
 }
 

--- a/instance/versions.tf
+++ b/instance/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/instance/volumes.tf
+++ b/instance/volumes.tf
@@ -9,6 +9,7 @@ resource "openstack_blockstorage_volume_v2" "my-volume" {
 }
 
 resource "openstack_compute_volume_attach_v2" "my-attachment" {
-  instance_id = "${openstack_compute_instance_v2.my-instance.id}"
-  volume_id   = "${openstack_blockstorage_volume_v2.my-volume.id}"
+  instance_id = openstack_compute_instance_v2.my-instance.id
+  volume_id   = openstack_blockstorage_volume_v2.my-volume.id
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,28 @@
 # Configure the OpenStack Provider
 provider "openstack" {
-  version          = "~> v1.19.0"
-  user_name        = "${var.username}"
-  domain_name      = "${var.domain_name}"
-  tenant_name      = "${var.tenant_name}"
-  user_domain_name = "${var.user_domain_name != "" ? var.user_domain_name : var.domain_name}"
-  password         = "${var.password}"
-  auth_url         = "${var.auth_url}"
-  region           = "${var.region}"
+  # version          = "~> v1.19.0"
+  user_name        = var.username
+  domain_name      = var.domain_name
+  tenant_name      = var.tenant_name
+  user_domain_name = var.user_domain_name != "" ? var.user_domain_name : var.domain_name
+  password         = var.password
+  auth_url         = var.auth_url
+  region           = var.region
 }
 
 module "vpc" {
   source  = "./vpc"
-  petname = "${random_pet.pet.id}"
+  petname = random_pet.pet.id
 }
 
 module "instance" {
-  instance_name  = "ts3"
-  source         = "./instance"
-  sec_id         = "${module.vpc.sec_id}"
-  petname        = "${random_pet.pet.id}"
+  instance_name = "ts3"
+  source        = "./instance"
+  sec_id        = module.vpc.sec_id
+  petname       = random_pet.pet.id
 }
 
 output "ip" {
-  value = "${module.instance.ip}"
+  value = module.instance.ip
 }
+

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ module "vpc" {
 module "instance" {
   instance_name = "ts3"
   source        = "./instance"
-  sec_id        = module.vpc.sec_id
+  sec_name        = module.vpc.sec_name
   petname       = random_pet.pet.id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Configure the OpenStack Provider
 provider "openstack" {
-  # version          = "~> v1.19.0"
+  version          = "~> v1.25"
   user_name        = var.username
   domain_name      = var.domain_name
   tenant_name      = var.tenant_name
@@ -8,6 +8,14 @@ provider "openstack" {
   password         = var.password
   auth_url         = var.auth_url
   region           = var.region
+}
+
+provider "random" {
+  version = "~> v2.2"
+}
+
+provider "template" {
+  version = "~> v2.1"
 }
 
 module "vpc" {

--- a/random.tf
+++ b/random.tf
@@ -1,1 +1,3 @@
-resource "random_pet" "pet" {}
+resource "random_pet" "pet" {
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,37 +1,37 @@
-variable username {
-  type = "string"
+variable "username" {
+  type = string
 }
 
-variable password {
-  type = "string"
+variable "password" {
+  type = string
 }
 
-variable domain_name {
+variable "domain_name" {
   # https://www.terraform.io/docs/providers/openstack/#domain_name
-  type = "string"
+  type = string
 }
 
-variable user_domain_name {
+variable "user_domain_name" {
   # https://www.terraform.io/docs/providers/openstack/#user_domain_name
-  type    = "string"
+  type    = string
   default = ""
 }
 
-variable tenant_name {
+variable "tenant_name" {
   # https://www.terraform.io/docs/providers/openstack/#tenant_name
-  type = "string"
+  type = string
 }
 
-variable project_id {
-  type = "string"
+variable "project_id" {
+  type = string
 }
 
-variable auth_url {
-  type = "string"
+variable "auth_url" {
+  type = string
 }
 
-variable region {
-  type    = "string"
+variable "region" {
+  type    = string
   default = "Karlsruhe"
 }
 
@@ -51,3 +51,4 @@ terraform {
     endpoint                    = "s3.eu-de.cloud-object-storage.appdomain.cloud"
   }
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "= 0.12.20"
 }

--- a/vpc/output.tf
+++ b/vpc/output.tf
@@ -1,3 +1,4 @@
 output "sec_id" {
-  value = "${openstack_networking_secgroup_v2.my-secgroup.id}"
+  value = openstack_networking_secgroup_v2.my-secgroup.id
 }
+

--- a/vpc/output.tf
+++ b/vpc/output.tf
@@ -1,4 +1,4 @@
-output "sec_id" {
-  value = openstack_networking_secgroup_v2.my-secgroup.id
+output "sec_name" {
+  value = openstack_networking_secgroup_v2.my-secgroup.name
 }
 

--- a/vpc/secgroups.tf
+++ b/vpc/secgroups.tf
@@ -10,7 +10,7 @@ resource "openstack_networking_secgroup_rule_v2" "terraform-ssh" {
   port_range_min    = 22
   port_range_max    = 22
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.my-secgroup.id}"
+  security_group_id = openstack_networking_secgroup_v2.my-secgroup.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ts3-udp" {
@@ -20,7 +20,7 @@ resource "openstack_networking_secgroup_rule_v2" "ts3-udp" {
   port_range_min    = 9987
   port_range_max    = 9987
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.my-secgroup.id}"
+  security_group_id = openstack_networking_secgroup_v2.my-secgroup.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ts3-tcp1" {
@@ -30,7 +30,7 @@ resource "openstack_networking_secgroup_rule_v2" "ts3-tcp1" {
   port_range_min    = 10011
   port_range_max    = 10011
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.my-secgroup.id}"
+  security_group_id = openstack_networking_secgroup_v2.my-secgroup.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ts3-tcp3" {
@@ -40,5 +40,6 @@ resource "openstack_networking_secgroup_rule_v2" "ts3-tcp3" {
   port_range_min    = 30033
   port_range_max    = 30033
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.my-secgroup.id}"
+  security_group_id = openstack_networking_secgroup_v2.my-secgroup.id
 }
+

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,4 +1,4 @@
-variable petname {
-  type = "string"
+variable "petname" {
+  type = string
 }
 

--- a/vpc/versions.tf
+++ b/vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Upgrade terraform code to 0.12

Pin terrafom version to 0.12.20
Pin used terraform provider versions

Fix a bug that cause the security group to be updated on every `terraform apply`
(this is caused by the OpenStack API accepting both name or id of the security group but always return its name, which leads to a deviation with the terraform state file)